### PR TITLE
added non interactive mode

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -248,10 +248,13 @@ class Launcher:
 
         # 4. launch the Steering Menu Handler
         # NOTE: this is to demonstrate the POC of steering via CLI
+        # TODO this POC handles both, interactive and non interactive steering
+        # -> refactor/rename to represent both -> generic steering
         poc_steering_menu = POCSteeringMenu(self._log_settings,
                                             self._configurations_manager,
                                             orchestrator_in_queue_proxy,
                                             orchestrator_out_queue_proxy,
-                                            communicate_via_zmqs=True)
+                                            communicate_via_zmqs=True,
+                                            is_interactive=False)
         poc_steering_menu.start_steering()
         return Response.OK

--- a/steering/steering_menu_handler.py
+++ b/steering/steering_menu_handler.py
@@ -24,9 +24,12 @@ class SteeringMenuCLIHandler:
     def __init__(self) -> None:
         self.__steering_menu_cli = SteeringMenuCLI()
         self.__current_choice = None
-
+    
     @property
     def current_selection(self): return self.__current_choice
+    
+    @property
+    def all_steering_commands(self): return self.__steering_menu_cli.steering_menu_items
 
     def display_steering_menu(self):
         print('\n'+'*' * 33, flush=True)


### PR DESCRIPTION
- if 'is_interactive' flag is False (default) -> steering commands are executed automatically
- added new property to steering_menu_handler.py -> all_steering_commands -> returns the dict_keys list of all menu items to iterate
- IMPORTANT: non interactive mode assumes correct order of steering commands in menu items. E.g. START, STOP, EXIT 

